### PR TITLE
Fix example

### DIFF
--- a/RISCV_ASM/examples/ast_factorial/factorial.c
+++ b/RISCV_ASM/examples/ast_factorial/factorial.c
@@ -1,6 +1,0 @@
-int factorial(int n) {
-    if (n == 0) {
-        return 1;
-    }
-    return n * factorial(n-1); 
-}

--- a/RISCV_ASM/examples/ast_factorial/factorial.s
+++ b/RISCV_ASM/examples/ast_factorial/factorial.s
@@ -1,12 +1,3 @@
-	.file	"factorial.c"
-	.option nopic
-	.attribute arch, "rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0"
-	.attribute unaligned_access, 0
-	.attribute stack_align, 16
-	.text
-	.align	1
-	.globl	factorial
-	.type	factorial, @function
 factorial:
 	mv	a5,a0
 	li	a0,1
@@ -18,5 +9,3 @@ factorial:
 	bne	a5,zero,.L2
 .L5:
 	ret
-	.size	factorial, .-factorial
-	.ident	"GCC: (gc891d8dc23e) 13.2.0"


### PR DESCRIPTION
Removal of directives (needed only for building .s code, not for interpreting)
Removal of factorial.c (now it doesn't map with factorial.s)