### PR TITLE
All instructions and directives now require either a whitespace or end of input after them

### DIFF
--- a/RISCV_ASM/tests/qc.t
+++ b/RISCV_ASM/tests/qc.t
@@ -1,4 +1,4 @@
-  $ ../quickcheck/quickcheck.exe -seed 53252525
-  random seed: 53252525
+  $ ../quickcheck/quickcheck.exe -seed 513426560
+  random seed: 513426560
   ================================================================================
   success (ran 1 tests)


### PR DESCRIPTION
It eliminates a bug where it would parse a single label (that has an instuction name in its name) as an instruction and the rest of the label